### PR TITLE
Fix wrong call to pixrem for processing

### DIFF
--- a/tasks/pixrem.js
+++ b/tasks/pixrem.js
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
 
       // Run Pixrem
       try {
-        output = pixrem(input, options.rootvalue, { replace: options.replace });
+        output = pixrem.process(input, options.rootvalue, { replace: options.replace });
       }
       catch (e) {
         var err = new Error('Pixrem failed.');


### PR DESCRIPTION
Newer version of pixrem seem to only return the instance of the Pixrem class when calling pixrem. To actually process a file you need to call pixrem.process passing the same arguments as before.
